### PR TITLE
Fix: Improve in-app display of reversed video duration

### DIFF
--- a/index.html
+++ b/index.html
@@ -300,6 +300,7 @@
             <div class="video-wrapper">
                 <h2>Reversed Video</h2>
                 <video id="reversedVideo" controls playsinline aria-label="Reversed video player"></video>
+                <p style="text-align: right; margin-top: 4px; font-size: 0.9em;">Duration: <span id="reversedVideoDurationDisplay">--:--</span></p>
             </div>
         </div>
 
@@ -371,6 +372,21 @@
         const videoUpload = document.getElementById('videoUpload'); // Input element for video file selection
         const originalVideo = document.getElementById('originalVideo'); // Video player for the original video
         const reversedVideo = document.getElementById('reversedVideo'); // Video player for the reversed video
+        reversedVideo.addEventListener('loadedmetadata', () => {
+            console.log('Reversed video (onloadedmetadata) reported duration:', reversedVideo.duration);
+            const durationDisplay = document.getElementById('reversedVideoDurationDisplay');
+            if (durationDisplay) {
+                if (reversedVideo.duration && reversedVideo.duration !== Infinity && !isNaN(reversedVideo.duration) && reversedVideo.duration > 0) {
+                    durationDisplay.textContent = formatTime(reversedVideo.duration);
+                } else if (originalVideo.duration && originalVideo.duration !== Infinity && !isNaN(originalVideo.duration)) {
+                    // If reversedVideo.duration is invalid, use originalVideo.duration as a fallback
+                    console.log('Reversed video duration is invalid, using original video duration as fallback for display.');
+                    durationDisplay.textContent = formatTime(originalVideo.duration) + ' (actual)';
+                } else {
+                    durationDisplay.textContent = '--:--'; // Fallback if no valid duration is found
+                }
+            }
+        });
         const reverseButton = document.getElementById('reverseButton'); // Button to start the video reversal process
         const downloadButton = document.getElementById('downloadButton'); // Button to download the reversed video
         const statusDisplay = document.getElementById('status'); // Element to display status messages
@@ -666,7 +682,23 @@
                 }
 
                 try {
-                    // Create a MediaStream from the canvas. This stream will provide frames to the MediaRecorder.
+                    // NOTE ON VIDEO DURATION METADATA:
+                    // MediaRecorder, especially when sourcing from a canvas stream and muxing audio,
+                    // often does not write accurate duration metadata into the resulting video file's header.
+                    // This can cause media players and file explorers to display the duration as 00:00
+                    // or an incorrect value, even if the video plays correctly for the full length.
+                    //
+                    // The actual stream recorded *does* have the correct length, determined by the number
+                    // of frames drawn and the FPS. The issue is purely with the metadata in the container
+                    // (e.g., WebM, MP4).
+                    //
+                    // Robustly fixing this usually requires remuxing the generated video file with tools
+                    // like ffmpeg to rebuild the container and insert correct metadata headers. This is
+                    // a complex operation not easily done client-side without large libraries (e.g., ffmpeg.wasm).
+                    //
+                    // The current implementation attempts to mitigate this for the in-app player by
+                    // displaying the original video's duration if the generated one is incorrect,
+                    // but the downloaded file may still exhibit the duration issue in external players.
                     const stream = frameCanvas.captureStream(fps);
                     if (!stream) {
                         reject(new Error("Failed to capture stream from canvas."));
@@ -731,8 +763,14 @@
                                 source.buffer = reversedAudioBuffer;
                                 // Create a MediaStreamDestinationNode to capture the audio output as a stream
                                 const dest = audioContext.createMediaStreamDestination();
+
+                                console.log('Original video duration:', originalVideo.duration);
+                                console.log('Decoded audioBuffer duration:', audioBuffer.duration);
+                                console.log('Reversed audioBuffer duration:', reversedAudioBuffer.duration);
+
                                 source.connect(dest); // Connect the source to the destination
                                 source.start(); // Start playing the reversed audio (into the destination stream)
+                                console.log('Reversed audio MediaStreamTrack settings:', dest.stream.getAudioTracks()[0].getSettings());
 
                                 // Combine the video stream (from canvas) and the reversed audio stream
                                 mixedStream = new MediaStream([...stream.getVideoTracks(), ...dest.stream.getAudioTracks()]);


### PR DESCRIPTION
Addresses an issue where reversed videos would show a duration of 00:00.

The primary changes include:
- Adding diagnostic logging to verify audio stream duration during processing.
- Logging the duration reported by the browser for the generated reversed video. It's expected that this will often be 0 due to MediaRecorder limitations with canvas streams.
- Implementing a fallback display for the reversed video's duration in the application UI. If the browser reports an invalid duration for the reversed video, the UI will now display the duration of the original video, suffixed with "(actual)".
- Adding code comments to document the known limitations of client-side MediaRecorder in accurately writing duration metadata to video files, explaining why the downloaded file might still show 00:00 in external players.

This solution enhances your in-app experience by providing a correct visual duration, while acknowledging the technical constraints that prevent a full fix for downloaded file metadata without more extensive tools (e.g., ffmpeg.wasm).