### PR TITLE
Feat: Prioritize avc3 H.264 codecs for MP4 output

### DIFF
--- a/index.html
+++ b/index.html
@@ -738,20 +738,26 @@
                     // often points to problems in the video track decoding, possibly related to
                     // keyframes or codec profile compatibility.
                     const mimeTypes = [
-                        // Specific H.264 & AAC combinations first
+                        // Prioritize avc3 (H.264 Annex B) as suggested by browser warnings
+                        'video/mp4; codecs="avc3.42E01E, mp4a.40.2"', // H.264 Baseline Profile Level 3.0 + AAC-LC
+                        'video/mp4; codecs="avc3.4D401E, mp4a.40.2"', // H.264 Main Profile Level 3.0 + AAC-LC
+                        'video/mp4; codecs="avc3.64001E, mp4a.40.2"', // H.264 High Profile Level 3.0 + AAC-LC
+
+                        // Fallback to avc1 (H.264 AVCC)
                         'video/mp4; codecs="avc1.42E01E, mp4a.40.2"', // H.264 Baseline + AAC-LC
                         'video/mp4; codecs="avc1.4D401E, mp4a.40.2"', // H.264 Main + AAC-LC
                         'video/mp4; codecs="avc1.64001E, mp4a.40.2"', // H.264 High + AAC-LC
-                        'video/mp4; codecs="h264, aac"',             // Generic H.264 + AAC
+                        'video/mp4; codecs="h264, aac"',             // Generic H.264 + AAC (often implies avc1)
 
-                        // H.264 video only (browser might add its own audio or fail if audio is expected)
+                        // H.264 video only (less likely to be chosen if audio is present in stream)
+                        'video/mp4; codecs="avc3.42E01E"',
                         'video/mp4; codecs="avc1.42E01E"',
                         'video/mp4; codecs="h264"',
 
-                        // Generic MP4 (let browser choose codecs - this is a key fallback)
+                        // Generic MP4 (let browser choose codecs)
                         'video/mp4',
 
-                        // WebM types as fallbacks
+                        // WebM types as ultimate fallbacks
                         'video/webm; codecs="vp9, opus"',
                         'video/webm; codecs="vp8, vorbis"',
                         'video/webm; codecs=vp9',


### PR DESCRIPTION
This commit updates the MediaRecorder MIME type preferences to prioritize `avc3` variants of H.264 video (e.g., `video/mp4; codecs="avc3.42E01E, mp4a.40.2"`) over `avc1` variants.

This change is in response to:
1. Browser console warnings suggesting the use of `avc3` instead of `avc1` when issues arise with MP4/H.264 encoding.
2. Your reports of generated MP4 files (using `avc1`) being a still image for the entire video duration.

Prioritizing `avc3` aims to improve compatibility and potentially resolve the still-image issue by using an H.264 parameter set format that the browser might handle more robustly for canvas-sourced recordings. `avc1` options and WebM remain as fallbacks.